### PR TITLE
Fix bug for addqn after viewflag command

### DIFF
--- a/src/main/java/team/serenity/logic/commands/ViewFlagCommand.java
+++ b/src/main/java/team/serenity/logic/commands/ViewFlagCommand.java
@@ -1,6 +1,9 @@
 package team.serenity.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static team.serenity.model.Model.PREDICATE_SHOW_ALL_GROUPS;
+import static team.serenity.model.Model.PREDICATE_SHOW_ALL_LESSONS;
+import static team.serenity.model.Model.PREDICATE_SHOW_ALL_QUESTIONS;
 
 import team.serenity.model.Model;
 
@@ -18,6 +21,9 @@ public class ViewFlagCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
+        model.updateFilteredLessonList(PREDICATE_SHOW_ALL_LESSONS);
+        model.updateFilteredQuestionList(PREDICATE_SHOW_ALL_QUESTIONS);
         return new CommandResult(MESSAGE_SUCCESS, CommandResult.UiAction.FLAG_ATT);
     }
 

--- a/src/main/java/team/serenity/logic/commands/question/EditQnCommand.java
+++ b/src/main/java/team/serenity/logic/commands/question/EditQnCommand.java
@@ -101,9 +101,7 @@ public class EditQnCommand extends Command {
 
         model.setQuestion(questionToEdit, editedQuestion);
         model.updateFilteredQuestionList(Model.PREDICATE_SHOW_ALL_QUESTIONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_QUESTION_SUCCESS, editedQuestion),
-                CommandResult.UiAction.VIEW_QN
-        );
+        return new CommandResult(String.format(MESSAGE_EDIT_QUESTION_SUCCESS, editedQuestion));
     }
 
     /**

--- a/src/main/java/team/serenity/logic/commands/question/FindQnCommand.java
+++ b/src/main/java/team/serenity/logic/commands/question/FindQnCommand.java
@@ -23,6 +23,10 @@ public class FindQnCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " deadline";
 
+    public static final String MESSAGE_TO_VIEW_ALL_QUESTIONS =
+            String.format("\nUse the \"%s\" command to show all questions from all tutorial groups and lessons.",
+                    ViewQnCommand.COMMAND_WORD);
+
     private final QuestionContainsKeywordPredicate predicate;
 
     public FindQnCommand(QuestionContainsKeywordPredicate predicate) {
@@ -34,10 +38,7 @@ public class FindQnCommand extends Command {
         requireNonNull(model);
         model.updateFilteredQuestionList(this.predicate);
         return new CommandResult(String.format(MESSAGE_QUESTIONS_LISTED_OVERVIEW,
-            model.getFilteredQuestionList().size(), "questions")
-            + String.format("\nUse the \"%s\" command to show all questions", ViewQnCommand.COMMAND_WORD),
-            CommandResult.UiAction.VIEW_QN
-        );
+                model.getFilteredQuestionList().size(), "questions") + MESSAGE_TO_VIEW_ALL_QUESTIONS);
     }
 
     @Override

--- a/src/main/java/team/serenity/logic/commands/question/ViewQnCommand.java
+++ b/src/main/java/team/serenity/logic/commands/question/ViewQnCommand.java
@@ -1,6 +1,8 @@
 package team.serenity.logic.commands.question;
 
 import static java.util.Objects.requireNonNull;
+import static team.serenity.model.Model.PREDICATE_SHOW_ALL_GROUPS;
+import static team.serenity.model.Model.PREDICATE_SHOW_ALL_LESSONS;
 import static team.serenity.model.Model.PREDICATE_SHOW_ALL_QUESTIONS;
 
 import team.serenity.logic.commands.Command;
@@ -22,6 +24,8 @@ public class ViewQnCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        model.updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
+        model.updateFilteredLessonList(PREDICATE_SHOW_ALL_LESSONS);
         model.updateFilteredQuestionList(PREDICATE_SHOW_ALL_QUESTIONS);
         return new CommandResult(MESSAGE_SUCCESS, CommandResult.UiAction.VIEW_QN);
     }

--- a/src/test/java/team/serenity/logic/commands/CommandTestUtil.java
+++ b/src/test/java/team/serenity/logic/commands/CommandTestUtil.java
@@ -169,11 +169,11 @@ public class CommandTestUtil {
     }
 
     /**
-     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)} that takes a string
-     * {@code expectedMessage}.
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandResult, Model)}
+     * that takes a string {@code expectedMessage} to test for viewQnCommand.
      */
-    public static void assertQuestionCommandSuccess(Command command, Model actualModel,
-                                                    String expectedMessage, Model expectedModel) {
+    public static void assertViewQnCommandSuccess(Command command, Model actualModel,
+                                                  String expectedMessage, Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage, CommandResult.UiAction.VIEW_QN);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/team/serenity/logic/commands/question/EditQnCommandTest.java
+++ b/src/test/java/team/serenity/logic/commands/question/EditQnCommandTest.java
@@ -11,8 +11,8 @@ import static team.serenity.logic.commands.CommandTestUtil.VALID_GROUP_NAME_G01;
 import static team.serenity.logic.commands.CommandTestUtil.VALID_GROUP_NAME_G05;
 import static team.serenity.logic.commands.CommandTestUtil.VALID_LESSON_NAME_1_2;
 import static team.serenity.logic.commands.CommandTestUtil.VALID_QN_DESC_B;
+import static team.serenity.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static team.serenity.logic.commands.CommandTestUtil.assertQuestionCommandFailure;
-import static team.serenity.logic.commands.CommandTestUtil.assertQuestionCommandSuccess;
 import static team.serenity.logic.commands.CommandTestUtil.showQuestionAtIndex;
 import static team.serenity.logic.commands.question.EditQnCommand.MESSAGE_DUPLICATE_QUESTION;
 import static team.serenity.logic.commands.question.EditQnCommand.MESSAGE_EDIT_QUESTION_SUCCESS;
@@ -78,7 +78,7 @@ class EditQnCommandTest {
 
         expectedModel.setQuestion(lastQuestion, editedQuestion);
 
-        assertQuestionCommandSuccess(editCommand, this.model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, this.model, expectedMessage, expectedModel);
 
     }
 
@@ -102,7 +102,7 @@ class EditQnCommandTest {
 
         expectedModel.setQuestion(lastQuestion, editedQuestion);
 
-        assertQuestionCommandSuccess(editCommand, this.model, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, this.model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/team/serenity/logic/commands/question/FindQnCommandTest.java
+++ b/src/test/java/team/serenity/logic/commands/question/FindQnCommandTest.java
@@ -3,7 +3,7 @@ package team.serenity.logic.commands.question;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static team.serenity.commons.core.Messages.MESSAGE_QUESTIONS_LISTED_OVERVIEW;
-import static team.serenity.logic.commands.CommandTestUtil.assertQuestionCommandSuccess;
+import static team.serenity.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static team.serenity.testutil.question.TypicalQuestion.QUESTION_A;
 import static team.serenity.testutil.question.TypicalQuestion.getTypicalQuestionManager;
 
@@ -63,22 +63,22 @@ class FindQnCommandTest {
     @Test
     public void execute_zeroKeywords_noQuestionFound() {
         String expectedMessage = String.format(MESSAGE_QUESTIONS_LISTED_OVERVIEW, 0, "questions")
-                + String.format("\nUse the \"%s\" command to show all questions", ViewQnCommand.COMMAND_WORD);
+                + FindQnCommand.MESSAGE_TO_VIEW_ALL_QUESTIONS;
         QuestionContainsKeywordPredicate predicate = preparePredicate(" ");
         FindQnCommand command = new FindQnCommand(predicate);
         this.expectedModel.updateFilteredQuestionList(predicate);
-        assertQuestionCommandSuccess(command, this.model, expectedMessage, this.expectedModel);
+        assertCommandSuccess(command, this.model, expectedMessage, this.expectedModel);
         assertEquals(Collections.emptyList(), this.model.getFilteredQuestionList());
     }
 
     @Test
     public void execute_multipleKeywords_multipleQuestionsFound() {
         String expectedMessage = String.format(MESSAGE_QUESTIONS_LISTED_OVERVIEW, 1, "questions")
-                + String.format("\nUse the \"%s\" command to show all questions", ViewQnCommand.COMMAND_WORD);
+                + FindQnCommand.MESSAGE_TO_VIEW_ALL_QUESTIONS;
         QuestionContainsKeywordPredicate predicate = preparePredicate("deadline");
         FindQnCommand command = new FindQnCommand(predicate);
         this.expectedModel.updateFilteredQuestionList(predicate);
-        assertQuestionCommandSuccess(command, this.model, expectedMessage, this.expectedModel);
+        assertCommandSuccess(command, this.model, expectedMessage, this.expectedModel);
         assertEquals(Collections.singletonList(QUESTION_A), this.model.getFilteredQuestionList());
     }
 

--- a/src/test/java/team/serenity/logic/commands/question/ViewQnCommandTest.java
+++ b/src/test/java/team/serenity/logic/commands/question/ViewQnCommandTest.java
@@ -1,6 +1,6 @@
 package team.serenity.logic.commands.question;
 
-import static team.serenity.logic.commands.CommandTestUtil.assertQuestionCommandSuccess;
+import static team.serenity.logic.commands.CommandTestUtil.assertViewQnCommandSuccess;
 import static team.serenity.logic.commands.CommandTestUtil.showQuestionAtIndex;
 import static team.serenity.testutil.TypicalIndexes.INDEX_FIRST;
 import static team.serenity.testutil.question.TypicalQuestion.getTypicalQuestionManager;
@@ -29,14 +29,14 @@ class ViewQnCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertQuestionCommandSuccess(new ViewQnCommand(), this.model,
+        assertViewQnCommandSuccess(new ViewQnCommand(), this.model,
                 ViewQnCommand.MESSAGE_SUCCESS, this.expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showQuestionAtIndex(this.model, INDEX_FIRST);
-        assertQuestionCommandSuccess(new ViewQnCommand(), this.model,
+        assertViewQnCommandSuccess(new ViewQnCommand(), this.model,
                 ViewQnCommand.MESSAGE_SUCCESS, this.expectedModel);
     }
 


### PR DESCRIPTION
Fix #332 
Close #332 

Fixed bug and other questions-related commands to ensure that `addqn` command cannot be used when not in lesson page.